### PR TITLE
Add get match method

### DIFF
--- a/cashews/backends/diskcache.py
+++ b/cashews/backends/diskcache.py
@@ -124,7 +124,7 @@ class DiskCache(Backend):
         for key in self._keys_match(pattern):
             self._cache.delete(key)
 
-    async def get_match(self, pattern: str):
+    async def get_match(self, pattern: str, count: int = None):
         if not self._sharded:
             for key in await self._run_in_executor(self._keys_match, pattern):
                 yield key, self._cache.get(key)

--- a/cashews/backends/diskcache.py
+++ b/cashews/backends/diskcache.py
@@ -124,6 +124,11 @@ class DiskCache(Backend):
         for key in self._keys_match(pattern):
             self._cache.delete(key)
 
+    async def get_match(self, pattern: str):
+        if not self._sharded:
+            for key in await self._run_in_executor(self._keys_match, pattern):
+                yield key, self._cache.get(key)
+
     async def expire(self, key: str, timeout: Union[float, int]):
         return await self._run_in_executor(self._cache.touch, key, timeout)
 

--- a/cashews/backends/interface.py
+++ b/cashews/backends/interface.py
@@ -59,7 +59,7 @@ class Backend:
     async def delete_match(self, pattern: str):
         ...
 
-    async def get_match(self, pattern: str):
+    async def get_match(self, pattern: str, count: int = 100):
         ...
 
     async def expire(self, key: str, timeout: Union[float, int]):
@@ -152,8 +152,8 @@ class ProxyBackend(Backend):
     def get_many(self, *keys: str) -> Tuple[Any]:
         return self._target.get_many(keys)
 
-    def get_match(self, pattern: str):
-        return self._target.get_match(pattern)
+    def get_match(self, pattern: str, count: int = 100):
+        return self._target.get_match(pattern, count)
 
     def exists(self, key):
         return self._target.exists(key)

--- a/cashews/backends/interface.py
+++ b/cashews/backends/interface.py
@@ -59,6 +59,9 @@ class Backend:
     async def delete_match(self, pattern: str):
         ...
 
+    async def get_match(self, pattern: str):
+        ...
+
     async def expire(self, key: str, timeout: Union[float, int]):
         ...
 
@@ -148,6 +151,9 @@ class ProxyBackend(Backend):
 
     def get_many(self, *keys: str) -> Tuple[Any]:
         return self._target.get_many(keys)
+
+    def get_match(self, pattern: str):
+        return self._target.get_match(pattern)
 
     def exists(self, key):
         return self._target.exists(key)

--- a/cashews/backends/memory.py
+++ b/cashews/backends/memory.py
@@ -92,6 +92,10 @@ class Memory(Backend):
         async for key in self.keys_match(pattern):
             self._delete(key)
 
+    async def get_match(self, pattern: str):
+        async for key in self.keys_match(pattern):
+            yield key, self._get(key)
+
     async def expire(self, key: str, timeout: float):
         if not self._key_exist(key):
             return

--- a/cashews/backends/memory.py
+++ b/cashews/backends/memory.py
@@ -92,7 +92,7 @@ class Memory(Backend):
         async for key in self.keys_match(pattern):
             self._delete(key)
 
-    async def get_match(self, pattern: str):
+    async def get_match(self, pattern: str, count: int = None):
         async for key in self.keys_match(pattern):
             yield key, self._get(key)
 

--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -171,6 +171,14 @@ class _Redis(Backend):
         if keys:
             return await self._client.unlink(keys[0], *keys[1:])
 
+    async def get_match(self, pattern: str):
+        keys = []
+        async for key in self.keys_match(pattern):
+            keys.append(key.decode())
+        values = await self.get_many(*keys)
+        for key, value in zip(keys, values):
+            yield key, value
+
     async def get_size(self, key: str) -> int:
         if AIOREDIS_IS_VERSION_1:
             size = await self._client.execute(b"MEMORY", b"USAGE", key)

--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -177,6 +177,8 @@ class _Redis(Backend):
 
     async def get_match(self, pattern: str):
         async for keys in self._scan(pattern):
+            if not keys:
+                continue
             keys = [key.decode() for key in keys]
             values = await self.get_many(*keys)
             for key, value in zip(keys, values):

--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -175,8 +175,8 @@ class _Redis(Backend):
         if keys:
             return await self._client.unlink(keys[0], *keys[1:])
 
-    async def get_match(self, pattern: str):
-        async for keys in self._scan(pattern):
+    async def get_match(self, pattern: str, count: int = 100):
+        async for keys in self._scan(pattern, count):
             if not keys:
                 continue
             keys = [key.decode() for key in keys]

--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, AsyncIterator, List
 
 from ..interface import Backend
 from .client import SafeRedis
@@ -155,10 +155,14 @@ class _Redis(Backend):
     async def exists(self, key) -> bool:
         return bool(await self._client.exists(key))
 
-    async def keys_match(self, pattern: str):
+    async def _scan(self, pattern: str, count=100) -> AsyncIterator[List[bytes]]:
         cursor = b"0"
         while cursor:
-            cursor, keys = await self._client.scan(cursor, match=pattern, count=100)
+            cursor, keys = await self._client.scan(cursor, match=pattern, count=count)
+            yield keys
+
+    async def keys_match(self, pattern: str):
+        async for keys in self._scan(pattern):
             for key in keys:
                 yield key
 
@@ -172,12 +176,11 @@ class _Redis(Backend):
             return await self._client.unlink(keys[0], *keys[1:])
 
     async def get_match(self, pattern: str):
-        keys = []
-        async for key in self.keys_match(pattern):
-            keys.append(key.decode())
-        values = await self.get_many(*keys)
-        for key, value in zip(keys, values):
-            yield key, value
+        async for keys in self._scan(pattern):
+            keys = [key.decode() for key in keys]
+            values = await self.get_many(*keys)
+            for key, value in zip(keys, values):
+                yield key, value
 
     async def get_size(self, key: str) -> int:
         if AIOREDIS_IS_VERSION_1:

--- a/cashews/helpers.py
+++ b/cashews/helpers.py
@@ -8,7 +8,7 @@ def add_prefix(prefix: str):
             return await call(*[prefix + key for key in args])
         call_values = get_call_values(call, args, kwargs)
         as_key = "key"
-        if cmd in ["delete_match", "keys_match"]:
+        if cmd in ["delete_match", "get_match", "keys_match"]:
             as_key = "pattern"
         key = call_values.get(as_key)
         if key:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -156,6 +156,26 @@ async def test_keys_match(cache: Backend):
     assert len(keys) == 4
 
 
+async def test_get_match(cache: Backend):
+    await cache.set("pref:test:test", b"value")
+    await cache.set("pref:value:test", b"value2")
+    await cache.set("pref:-:test", b"-")
+    await cache.set("pref:*:test", b"*")
+
+    await cache.set("ppref:test:test", b"value3")
+    await cache.set("pref:test:tests", b"value3")
+
+    match = [(key, value) async for key, value in cache.get_match("pref:*:test")]
+
+    assert len(match) == 4
+    assert dict(match) == {
+        "pref:test:test": b"value",
+        "pref:value:test": b"value2",
+        "pref:-:test": b"-",
+        "pref:*:test": b"*",
+    }
+
+
 async def test_get_size(cache: Backend):
     await cache.set("test", b"1")
     assert await cache.get_size("test") in (

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -174,6 +174,8 @@ async def test_get_match(cache: Backend):
         "pref:-:test": b"-",
         "pref:*:test": b"*",
     }
+    match = [(key, value) async for key, value in cache.get_match("not_exists:*")]
+    assert len(match) == 0
 
 
 async def test_get_size(cache: Backend):


### PR DESCRIPTION
I think that this new method `get_match` should be useful for users. It allows to get values for all keys matched by pattern. This method contains `keys_match` and `get_many`.

Code example:
```python
await cache.set("test:aaa", "123")
await cache.set("test:bbb", "321")
await cache.set("test2:ccc", "999")

match = {key: value async for key, value in cache.get_match("test:*")}
match
# {"test:aaa": "123", "test:bbb": "321"}
```

I'm pretty unsure about this PR, so please comment if anything is wrong.