### PR TITLE
Add minimalist "pre-commit" config

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,3 @@
 [settings]
-sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-default_section=THIRDPARTY
-known_localfolder=cachews
-include_trailing_comma=True
-line_length=119
-multi_line_output=3
+profile = black
+line_length = 119

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-        args: [--line-length=160]
+        args: [--line-length=119]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.37.3
+    hooks:
+      - id: pyupgrade
+        # Specify the oldest Python version that "cashews" supports.
+        args: [--py37-plus]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        args: [--line-length=160]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        stages: [commit]
+
+  - repo: https://gitlab.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8

--- a/Readme.md
+++ b/Readme.md
@@ -671,6 +671,13 @@ cache.setup("mem://", middlewares=(logging_middleware, ))
 
 ## Development
 
+### Setup
+- Clone the project.
+- After creating a virtual environment, install [pre-commit](https://pre-commit.com/):
+  ```shell
+  pip install pre-commit && pre-commit install --install-hooks
+  ```
+
 ### Tests
 To run tests you can use `tox`:
 ```shell

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,5 +49,12 @@ tests =
 
 [flake8]
 exclude = venv/*,tox/*,specs/*
-ignore = E123,E128,E266,E402,W503,E731,W601
+ignore =
+    # Black compatibility: https://black.readthedocs.io/en/stable/faq.html#why-are-flake8-s-e203-and-w503-violated
+    # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#id1
+    E203, W503
+    # E402 Module level import not at top of file
+    E402,
+    # E731 Do not assign a lambda expression, use a def
+    E731
 max-line-length = 119


### PR DESCRIPTION
Configuration includes only the most popular and fundamental linters:
- flake8
- Black
- isort
- pyupgrade
- prettier

All the mention linters only auto-format files (except Flake8) and are fully compatible.

I did not edit the "Makefile" because I wonder why some people use it. If required, I can update the "Makefile" too, but you will need to tell me its purpose, how and where it is used. 

If the changes are OK, then I will push an auto-formatted code in a separate pull request.