### PR TITLE
refactor!: replace `Exception` prefix with `Error` prefix

### DIFF
--- a/cashews/__init__.py
+++ b/cashews/__init__.py
@@ -1,12 +1,6 @@
 from ._cache_condition import NOT_NONE  # noqa
-from .backends.interface import CacheBackendInteractionException, LockedException  # noqa
-from .decorators import (  # noqa
-    CacheDetect,
-    CircuitBreakerOpen,
-    RateLimitException,
-    context_cache_detect,
-    fast_condition,
-)
+from .backends.interface import CacheBackendInteractionError, LockedError  # noqa
+from .decorators import CacheDetect, CircuitBreakerOpen, RateLimitError, context_cache_detect, fast_condition  # noqa
 from .formatter import default_formatter, get_template_and_func_for, get_template_for_key  # noqa
 from .helpers import add_prefix, all_keys_lower, memory_limit  # noqa
 from .key import noself  # noqa

--- a/cashews/_picklers.py
+++ b/cashews/_picklers.py
@@ -58,7 +58,7 @@ _picklers = {
 }
 
 
-class UnsupportedPicklerException(Exception):
+class UnsupportedPicklerError(Exception):
     """
     Unknown or unsupported pickle type
     """
@@ -66,12 +66,12 @@ class UnsupportedPicklerException(Exception):
 
 def get_pickler(name: str):
     if name not in _picklers:
-        raise UnsupportedPicklerException()
+        raise UnsupportedPicklerError()
 
     if name == "sqlalchemy" and not _SQLALC_PICKLE:
-        raise UnsupportedPicklerException()
+        raise UnsupportedPicklerError()
 
     if name == "dill" and not _DILL_PICKLE:
-        raise UnsupportedPicklerException()
+        raise UnsupportedPicklerError()
 
     return _picklers[name]

--- a/cashews/backends/interface.py
+++ b/cashews/backends/interface.py
@@ -3,11 +3,11 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Mapping, Optional, Tuple
 
 
-class LockedException(Exception):
+class LockedError(Exception):
     pass
 
 
-class CacheBackendInteractionException(Exception):
+class CacheBackendInteractionError(Exception):
     pass
 
 
@@ -121,7 +121,7 @@ class Backend:
             except Exception:
                 pass
             else:
-                raise LockedException(f"Key {key} already locked")
+                raise LockedError(f"Key {key} already locked")
         try:
             yield
         finally:

--- a/cashews/backends/redis/client.py
+++ b/cashews/backends/redis/client.py
@@ -3,7 +3,7 @@ import logging
 import socket
 from typing import Any
 
-from cashews.backends.interface import CacheBackendInteractionException
+from cashews.backends.interface import CacheBackendInteractionError
 
 try:
     from redis.asyncio import Redis as _Redis
@@ -21,7 +21,7 @@ class Redis(_Redis):
         try:
             return await super().execute_command(command, *args, **kwargs)
         except (RedisConnectionError, socket.gaierror, OSError, asyncio.TimeoutError) as exp:
-            raise CacheBackendInteractionException() from exp
+            raise CacheBackendInteractionError() from exp
 
 
 class SafeRedis(_Redis):
@@ -30,7 +30,7 @@ class SafeRedis(_Redis):
             return await super().execute_command(command, *args, **kwargs)
         except (RedisConnectionError, socket.gaierror, OSError, asyncio.TimeoutError) as exp:
             if command.lower() == "ping":
-                raise CacheBackendInteractionException() from exp
+                raise CacheBackendInteractionError() from exp
             logger.error("redis: can not execute command: %s", command, exc_info=True)
             if command.lower() in ["unlink", "del", "memory", "ttl"]:
                 return 0

--- a/cashews/decorators/__init__.py
+++ b/cashews/decorators/__init__.py
@@ -8,4 +8,4 @@ from .cache.simple import cache  # noqa
 from .cache.soft import soft  # noqa
 from .circuit_breaker import CircuitBreakerOpen, circuit_breaker  # noqa
 from .locked import locked  # noqa
-from .rate import RateLimitException, rate_limit  # noqa
+from .rate import RateLimitError, rate_limit  # noqa

--- a/cashews/decorators/locked.py
+++ b/cashews/decorators/locked.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import Optional, Union
 
-from ..backends.interface import Backend, LockedException
+from ..backends.interface import Backend, LockedError
 from ..key import get_cache_key, get_cache_key_template
 
 __all__ = ("locked",)
@@ -36,7 +36,7 @@ def locked(
             try:
                 async with backend.lock(_cache_key, ttl or max_lock_ttl):
                     return await func(*args, **kwargs)
-            except LockedException:
+            except LockedError:
                 if not await backend.is_locked(_cache_key, wait=ttl, step=step):
                     return await func(*args, **kwargs)
                 raise

--- a/cashews/decorators/rate.py
+++ b/cashews/decorators/rate.py
@@ -9,12 +9,12 @@ from ..key import get_cache_key, get_cache_key_template
 logger = logging.getLogger(__name__)
 
 
-class RateLimitException(Exception):
+class RateLimitError(Exception):
     pass
 
 
 def _default_action(*args: Any, **kwargs: Any) -> NoReturn:
-    raise RateLimitException()
+    raise RateLimitError()
 
 
 def rate_limit(
@@ -33,7 +33,7 @@ def rate_limit(
     :param limit: number of calls
     :param period: Period
     :param ttl: time ban, default == period
-    :param action: call when rate limit reached, default raise RateLimitException
+    :param action: call when rate limit reached, default raise RateLimitError
     :param prefix: custom prefix for key, default 'rate_limit'
     """
     action = _default_action if action is None else action

--- a/cashews/key.py
+++ b/cashews/key.py
@@ -11,7 +11,7 @@ _ARGS = "__args__"
 _ARGS_KWARGS = (_ARGS, _KWARGS)
 
 
-class WrongKeyException(ValueError):
+class WrongKeyError(ValueError):
     """Raised If key template have wrong parameter"""
 
 
@@ -144,7 +144,7 @@ def _check_key_params(key, func_params):
     check = _ReplaceFormatter(default=_default)
     check.format(key, **func_params)
     if errors:
-        raise WrongKeyException(f"Wrong parameter placeholder '{errors}' in the key ")
+        raise WrongKeyError(f"Wrong parameter placeholder '{errors}' in the key ")
 
 
 def get_call_values(func: Callable, args, kwargs) -> Dict:

--- a/examples/app.py
+++ b/examples/app.py
@@ -16,7 +16,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.status import HTTP_403_FORBIDDEN
 
-from cashews import LockedException, RateLimitException, cache, utils
+from cashews import LockedError, RateLimitError, cache, utils
 
 database = databases.Database("sqlite:///db.sqlite")
 metadata = sqlalchemy.MetaData()
@@ -109,16 +109,16 @@ async def add_from_cache_headers(request: Request, call_next):
     return response
 
 
-@app.exception_handler(RateLimitException)
-async def rate_limit_handler(request, exc: RateLimitException):
+@app.exception_handler(RateLimitError)
+async def rate_limit_handler(request, exc: RateLimitError):
     return JSONResponse(
         status_code=429,
         content={"error": "too much"},
     )
 
 
-@app.exception_handler(LockedException)
-async def lock_handler(request, exc: LockedException):
+@app.exception_handler(LockedError)
+async def lock_handler(request, exc: LockedError):
     return JSONResponse(
         status_code=500,
         content={"error": "LOCK"},
@@ -168,7 +168,7 @@ async def get_me(user: User = Depends(get_current_user)):
     return {"name": user.name, "friends": friends}
 
 
-class RedisDownException(Exception):
+class RedisDownError(Exception):
     pass
 
 

--- a/examples/bench_app.py
+++ b/examples/bench_app.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 from fastapi import FastAPI
 
-from cashews import Cache, LockedException, RateLimitException, cache, context_cache_detect, mem, utils  # noqa: F401
+from cashews import Cache, LockedError, RateLimitError, cache, context_cache_detect, mem, utils  # noqa: F401
 
 app = FastAPI()
 cache.setup("mem://")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -137,7 +137,6 @@ async def test_cache_simple_none(backend):
         mock()
         return None
 
-    assert False
     assert await func() is None
     assert mock.call_count == 1
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -137,6 +137,7 @@ async def test_cache_simple_none(backend):
         mock()
         return None
 
+    assert False
     assert await func() is None
     assert mock.call_count == 1
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from cashews.backends.memory import Memory
-from cashews.decorators.rate import RateLimitException
+from cashews.decorators.rate import RateLimitError
 from cashews.decorators.rate import rate_limit as _rate_limit
 
 pytestmark = pytest.mark.asyncio
@@ -26,7 +26,7 @@ async def test_rate_limit_simple(rate_limit, n):
     for i in range(n):
         assert await func() == 1
 
-    with pytest.raises(RateLimitException):
+    with pytest.raises(RateLimitError):
         await func()
 
     await asyncio.sleep(0.01)
@@ -40,11 +40,11 @@ async def test_rate_limit_ttl(rate_limit):
 
     assert await func() == 1
 
-    with pytest.raises(RateLimitException):
+    with pytest.raises(RateLimitError):
         await func()
 
     await asyncio.sleep(0.01)
-    with pytest.raises(RateLimitException):
+    with pytest.raises(RateLimitError):
         await func()
 
     await asyncio.sleep(0.01)
@@ -60,7 +60,7 @@ async def test_rate_limit_func_args_dict(rate_limit):
 
     assert await func(obj) == "test"
 
-    with pytest.raises(RateLimitException):
+    with pytest.raises(RateLimitError):
         await func(obj)
 
     obj = type("user", (), {"name": "new"})()

--- a/tests/test_redis_down.py
+++ b/tests/test_redis_down.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from cashews.backends.interface import CacheBackendInteractionException
+from cashews.backends.interface import CacheBackendInteractionError
 from cashews.wrapper import Cache
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.redis]
@@ -48,16 +48,16 @@ async def test_safe_redis(redis_backend):
     assert await redis.delete("test") == 0
     await redis.delete_match("*")
 
-    with pytest.raises(CacheBackendInteractionException):
+    with pytest.raises(CacheBackendInteractionError):
         await redis.ping()
 
 
 async def test_unsafe_redis_down(redis_backend):
     redis = redis_backend(safe=False, address="redis://localhost:9223", hash_key=None)
     await redis.init()
-    with pytest.raises(CacheBackendInteractionException):
+    with pytest.raises(CacheBackendInteractionError):
         await redis.ping()
-    with pytest.raises(CacheBackendInteractionException):
+    with pytest.raises(CacheBackendInteractionError):
         await redis.set("key", "value")
 
 


### PR DESCRIPTION
BREAKING CHANGE: exceptions renamed

Rationale:
1. As defined in https://peps.python.org/pep-0008/:
    >  Class naming conventions apply here, although you should add
    >  the suffix “**Error**” to your exception classes if the exception
    >  is an error. Non-error exceptions that are used for non-local
    >  flow control or other forms of signaling need no special
    >  suffix.
2. The `Error` prefix is shorter than `Exception`, so this allows more easily fitting into an acceptable line length.