### PR TITLE
refactor: move exceptions into a single file

### DIFF
--- a/cashews/__init__.py
+++ b/cashews/__init__.py
@@ -1,6 +1,6 @@
 from ._cache_condition import NOT_NONE  # noqa
-from .backends.interface import CacheBackendInteractionError, LockedError  # noqa
 from .decorators import CacheDetect, CircuitBreakerOpen, RateLimitError, context_cache_detect, fast_condition  # noqa
+from .exceptions import CacheBackendInteractionError, LockedError  # noqa
 from .formatter import default_formatter, get_template_and_func_for, get_template_for_key  # noqa
 from .helpers import add_prefix, all_keys_lower, memory_limit  # noqa
 from .key import noself  # noqa

--- a/cashews/_picklers.py
+++ b/cashews/_picklers.py
@@ -1,6 +1,8 @@
 import pickle
 from typing import Any
 
+from .exceptions import UnsupportedPicklerError
+
 _SQLALC_PICKLE = True
 try:
     from sqlalchemy.ext import serializer as sqlalchemy_pickle
@@ -56,12 +58,6 @@ _picklers = {
     "sqlalchemy": SQLAlchemyPickler,
     "dill": DillPickler,
 }
-
-
-class UnsupportedPicklerError(Exception):
-    """
-    Unknown or unsupported pickle type
-    """
 
 
 def get_pickler(name: str):

--- a/cashews/backends/interface.py
+++ b/cashews/backends/interface.py
@@ -2,13 +2,7 @@ import uuid
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Mapping, Optional, Tuple
 
-
-class LockedError(Exception):
-    pass
-
-
-class CacheBackendInteractionError(Exception):
-    pass
+from ..exceptions import LockedError
 
 
 class Backend:

--- a/cashews/backends/redis/client.py
+++ b/cashews/backends/redis/client.py
@@ -3,7 +3,7 @@ import logging
 import socket
 from typing import Any
 
-from cashews.backends.interface import CacheBackendInteractionError
+from ...exceptions import CacheBackendInteractionError
 
 try:
     from redis.asyncio import Redis as _Redis

--- a/cashews/decorators/locked.py
+++ b/cashews/decorators/locked.py
@@ -1,7 +1,8 @@
 from functools import wraps
 from typing import Optional, Union
 
-from ..backends.interface import Backend, LockedError
+from ..backends.interface import Backend
+from ..exceptions import LockedError
 from ..key import get_cache_key, get_cache_key_template
 
 __all__ = ("locked",)

--- a/cashews/decorators/rate.py
+++ b/cashews/decorators/rate.py
@@ -3,14 +3,11 @@ from functools import wraps
 from typing import Any, Callable, NoReturn, Optional
 
 from ..backends.interface import Backend
+from ..exceptions import RateLimitError
 from ..formatter import register_template
 from ..key import get_cache_key, get_cache_key_template
 
 logger = logging.getLogger(__name__)
-
-
-class RateLimitError(Exception):
-    pass
 
 
 def _default_action(*args: Any, **kwargs: Any) -> NoReturn:

--- a/cashews/exceptions.py
+++ b/cashews/exceptions.py
@@ -3,9 +3,7 @@ class CacheError(Exception):
 
 
 class UnsupportedPicklerError(CacheError):
-    """
-    Unknown or unsupported pickle type
-    """
+    """Unknown or unsupported pickle type."""
 
 
 class UnSecureDataError(CacheError):
@@ -17,7 +15,7 @@ class SignIsMissingError(CacheError):
 
 
 class WrongKeyError(CacheError):
-    """Raised If key template have wrong parameter"""
+    """Raised If key template have wrong parameter."""
 
 
 class LockedError(CacheError):

--- a/cashews/exceptions.py
+++ b/cashews/exceptions.py
@@ -1,0 +1,32 @@
+class CacheError(Exception):
+    pass
+
+
+class UnsupportedPicklerError(CacheError):
+    """
+    Unknown or unsupported pickle type
+    """
+
+
+class UnSecureDataError(CacheError):
+    pass
+
+
+class SignIsMissingError(CacheError):
+    ...
+
+
+class WrongKeyError(CacheError):
+    """Raised If key template have wrong parameter"""
+
+
+class LockedError(CacheError):
+    pass
+
+
+class CacheBackendInteractionError(CacheError):
+    pass
+
+
+class RateLimitError(CacheError):
+    pass

--- a/cashews/key.py
+++ b/cashews/key.py
@@ -4,15 +4,12 @@ from functools import lru_cache
 from typing import Any, Callable, Container, Dict, Optional, Tuple, Union
 
 from ._typing import TTL
+from .exceptions import WrongKeyError
 from .formatter import _ReplaceFormatter, default_formatter, template_to_pattern
 
 _KWARGS = "__kwargs__"
 _ARGS = "__args__"
 _ARGS_KWARGS = (_ARGS, _KWARGS)
-
-
-class WrongKeyError(ValueError):
-    """Raised If key template have wrong parameter"""
 
 
 def ttl_to_seconds(ttl: Union[float, None, TTL]) -> Union[int, None, float]:

--- a/cashews/serialize.py
+++ b/cashews/serialize.py
@@ -4,16 +4,9 @@ from contextlib import suppress
 from typing import Any, Dict, Optional, Tuple, Union
 
 from ._picklers import DEFAULT_PICKLE, get_pickler
+from .exceptions import SignIsMissingError, UnSecureDataError
 
 BLANK_DIGEST = b""
-
-
-class UnSecureDataError(Exception):
-    pass
-
-
-class SignIsMissingError(Exception):
-    ...
 
 
 class PickleSerializerMixin:

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 
+from cashews.exceptions import WrongKeyError
 from cashews.formatter import default_formatter, get_template_and_func_for, get_template_for_key, register_template
 from cashews.key import get_cache_key, get_cache_key_template, ttl_to_seconds
 
@@ -208,7 +209,7 @@ def test_get_key_template(func, key, template):
 
 
 def test_get_key_template_error():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(WrongKeyError) as exc:
         get_cache_key_template(func1, "key:{wrong_key}:{a}")
     exc.match("wrong_key")
 

--- a/tests/test_redis_down.py
+++ b/tests/test_redis_down.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from cashews.backends.interface import CacheBackendInteractionError
+from cashews import CacheBackendInteractionError
 from cashews.wrapper import Cache
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.redis]


### PR DESCRIPTION
Since most of the exceptions are for internal use, the change must not be breaking for the end users. Exceptions which are designed to be used by the end users (`CacheBackendInteractionError`, `LockedError`) are still available via the same import command.