### PR TITLE
fix: skip redis=5.0.1 version as broken and close connection pool

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,13 @@ jobs:
         run: |
           tox -e py-redis
 
+      - name: Redis Test Suit (4)
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+        run: |
+          tox -e py-redis4
+
       - name: Diskcache Test Suit
         run: |
           tox -e py-diskcache

--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -300,5 +300,5 @@ class _Redis(Backend):
         return await self._client.dbsize()
 
     async def close(self):
-        await self._client.close()
+        await self._client.close(close_connection_pool=True)
         self.__is_init = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ cashews = py.typed
 
 [options.extras_require]
 redis =
-    redis >= 4.3.1
+    redis >= 4.3.1,!=5.0.1
 diskcache =
     diskcache >= 5.0.0
 speedup =

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     {py38,py39,py310,py311}
     {py38,py39,py310,py311}-redis
+    {py38,py39,py310,py311}-redis4
     {py38,py39,py310,py311}-diskcache
     {py38,py39,py310,py311}-integration
     coverage
@@ -13,6 +14,7 @@ setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     MARKER = not redis and not integration and not diskcache
     {py,py38,py39,py310,py311}-redis:       MARKER = redis and not diskcache
+    {py,py38,py39,py310,py311}-redis4:      MARKER = redis and not diskcache
     {py,py38,py39,py310,py311}-diskcache:   MARKER = diskcache and not redis
     {py,py38,py39,py310,py311}-integration: MARKER = integration
 deps =
@@ -21,6 +23,7 @@ deps =
     pytest-cov
     pytest-rerunfailures
     hypothesis
+    {py,py38,py39,py310,py311}-redis4: redis==4.6.0
     {py,py38,py39,py310,py311}-integration: aiohttp
     {py,py38,py39,py310,py311}-integration: fastapi
     {py,py38,py39,py310,py311}-integration: httpx
@@ -48,5 +51,6 @@ commands =
 depends =
     {py38,py39,py310,py311}
     {py38,py39,py310,py311}-redis
+    {py38,py39,py310,py311}-redis4
     {py38,py39,py310,py311}-diskcache
     {py38,py39,py310,py311}-integration


### PR DESCRIPTION
related to https://github.com/Krukov/cashews/issues/164