### PR TITLE
Handle Possible Return Types for spop

### DIFF
--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -304,7 +304,14 @@ class _Redis(Backend):
         await self._client.srem(key, *values)
 
     async def set_pop(self, key: Key, count: int = 100) -> Iterable[str]:
-        return [value.decode() for value in await self._client.spop(key, count)]  # type: ignore[union-attr]
+        values = await self._client.spop(key, count)
+        if values is None:
+            return []
+
+        if isinstance(values, str):
+            values = [values]
+
+        return [value.decode() for value in values]  # type: ignore[union-attr]
 
     async def get_keys_count(self) -> int:
         return await self._client.dbsize()

--- a/cashews/backends/redis/backend.py
+++ b/cashews/backends/redis/backend.py
@@ -308,7 +308,7 @@ class _Redis(Backend):
         if values is None:
             return []
 
-        if isinstance(values, str):
+        if isinstance(values, bytes):
             values = [values]
 
         return [value.decode() for value in values]  # type: ignore[union-attr]

--- a/tests/test_redis_down.py
+++ b/tests/test_redis_down.py
@@ -44,6 +44,9 @@ async def test_safe_redis(redis_backend):
     async for _ in redis.get_match("*"):
         raise AssertionError()
 
+    assert await redis.set_add("testset", "test") is None
+    assert await redis.set_pop("testset") == []
+
     assert await redis.delete("test") == 0
     await redis.delete_match("*")
 


### PR DESCRIPTION
When using the Redis client side with suppression on, and the backend fails to initialize, `spop` returns `None` because `SafeRedis` is used.

This PR handles the case by adding a branch for all return values of `spop` as per https://redis.io/docs/latest/commands/spop/.

The added test (without the fix) would fail with `FAILED tests/test_redis_down.py::test_safe_redis - TypeError: 'NoneType' object is not iterable`.

I ran the `py-redis`, `py-redis4` and `py` test environments locally and they succeeded.