### PR TITLE
Fix decoding of streaming response, which contains headers with colons

### DIFF
--- a/cashews/contrib/_starlette.py
+++ b/cashews/contrib/_starlette.py
@@ -18,7 +18,7 @@ async def encode_streaming_response(
 async def decode_streaming_response(value: bytes, backend: Backend, key: str, **kwargs) -> StreamingResponse:
     if not await backend.get(f"{key}:done"):
         raise DecodeError()
-    status_code, headers = value.split(b":")
+    status_code, headers = value.split(b":", maxsplit=1)
     raw_headers = []
     for header in headers.split(b";"):
         if not header:


### PR DESCRIPTION
Fix: Fix decoding of streaming response, which contains headers with colons (#324)

## Description

This PR resolves the issue described in #324. The bug occurs when decoding streaming responses with headers containing colons (:), causing a decoding error.

## Proposed Solution

When decoding the raw value and splitting `status_code` from `headers`, use only a single split.

## Changes Made

    Updated `decode_streaming_response` to handle colons in headers.
