### PR TITLE
Locking check interval

### DIFF
--- a/cashews/backends/interface.py
+++ b/cashews/backends/interface.py
@@ -146,7 +146,9 @@ class _BackendInterface(metaclass=ABCMeta):
     async def unlock(self, key: Key, value: Value) -> bool: ...
 
     @asynccontextmanager
-    async def lock(self, key: Key, expire: float, wait: bool = True) -> AsyncGenerator[None, None]:
+    async def lock(
+        self, key: Key, expire: float, wait: bool = True, check_interval: float = 0
+    ) -> AsyncGenerator[None, None]:
         identifier = str(uuid.uuid4())
         while True:
             lock = await self.set_lock(key, identifier, expire=expire)
@@ -163,7 +165,7 @@ class _BackendInterface(metaclass=ABCMeta):
                     return
 
                 if wait:
-                    await asyncio.sleep(0)
+                    await asyncio.sleep(check_interval)
                     continue
                 raise LockedError(f"Key {key} is already locked")
             try:

--- a/cashews/wrapper/decorators.py
+++ b/cashews/wrapper/decorators.py
@@ -360,6 +360,7 @@ class DecoratorsWrapper(Wrapper):
         key: KeyOrTemplate | None = None,
         wait: bool = True,
         prefix: str = "locked",
+        check_interval: float = 0,
     ) -> Callable[[DecoratedFunc], DecoratedFunc]:
         return decorators.locked(
             backend=self,  # type: ignore[arg-type]
@@ -367,6 +368,7 @@ class DecoratorsWrapper(Wrapper):
             key=key,
             wait=wait,
             prefix=prefix,
+            check_interval=check_interval,
         )
 
     def bloom(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,7 @@ async def _backend(request, redis_dsn, backend_factory):
         backend = backend_factory(Memory, check_interval=0.01)
     try:
         await backend.init()
+        await backend.clear()
         yield backend, request.param
     finally:
         await backend.close()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -209,7 +209,7 @@ async def test_multilayer_cache(cache: Cache):
 async def test_cache_lock(cache: Cache):
     m = Mock()
 
-    @cache(ttl=3, lock=True)
+    @cache(ttl=3, lock=True, protected=False)
     async def my_func(val=1):
         await asyncio.sleep(0)  # for task switching
         m(val)


### PR DESCRIPTION
Adds a `check_interval` option to the `@cache.locked` decorator, which controls how long the backend will wait in between attempts to set the lock while another task has acquired the lock.

This helps avoid hitting the backend _many_ times in a short timespan when concurrent async tasks or processes are trying to run the same locked function.

The default behavior of the lib is unchanged as the default value of `check_interval=0`, so it still does `await asyncio.sleep(0)` to just proceed to the next task on the event loop without wait when the argument is not specified.

More context in #333. This gives a "good enough" solution for my use case for now but we may consider using a pub/sub approach in the future for backends that could support it (Redis). 

Also a couple small test updates (let me know if you want me to separate these out):
1. Clear the backend before every test. I noticed that tests could affect each other while I was hacking on them
2. Add `protected=False` to the `@cache(lock=True)` test as when `protected=True` the test passes without even passing `lock=True`.
