### PR TITLE
Fix _is_early_cache IndexError for empty list responses

### DIFF
--- a/cashews/contrib/fastapi.py
+++ b/cashews/contrib/fastapi.py
@@ -192,7 +192,7 @@ def _get_etag(cached_data: Any) -> str:
 
 
 def _is_early_cache(data: Any) -> bool:
-    return isinstance(data, list) and isinstance(data[0], datetime)
+    return isinstance(data, list) and data and isinstance(data[0], datetime)
 
 
 class CacheDeleteMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
This PR fixes a potential `IndexError` in the `_is_early_cache` function when a FastAPI endpoint returns an empty list.

**Issue:**

```python
def _is_early_cache(data: Any) -> bool:
    return isinstance(data, list) and isinstance(data[0], datetime)
```

If `data` is an empty list, `data[0]` raises an `IndexError`.

**Fix:**

```python
def _is_early_cache(data: Any) -> bool:
    return isinstance(data, list) and data and isinstance(data[0], datetime)
```

This ensures the list is non-empty before accessing its first element.

**Reproduction:**

```python
@app.get("/demo")
@disk_cache(ttl="15s")
async def empty_list() -> list[dict]:
    return []
```

This endpoint triggers the error without the fix when returning an empty list.
