### PR TITLE
Force script registration on redis reconnect

### DIFF
--- a/cashews/backends/redis/client_side.py
+++ b/cashews/backends/redis/client_side.py
@@ -124,6 +124,7 @@ class BcastClientSide(Redis):
                 await self._listen_invalidate()
             except (RedisConnectionError, ConnectionRefusedError):
                 logger.error("broken connection with redis. Clearing client side storage")
+                self._sha = {}
                 self._listen_started.clear()
                 await self._local_cache.clear()
                 await asyncio.sleep(_RECONNECT_WAIT)


### PR DESCRIPTION
We're using cashews on GCP, on a valkey primary/replica setup. When google promotes the replica to primary, we get lots of errors like this one:

```
2025-10-21 11:37:22,067 - cashews.backends.redis.client - ERROR - redis: can not execute command: EVALSHA
Traceback (most recent call last):
  File "/Users/gervasio/.pyenv/versions/api/lib/python3.11/site-packages/cashews/backends/redis/client.py", line 31, in execute_command
    return await super().execute_command(command, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gervasio/.pyenv/versions/api/lib/python3.11/site-packages/redis/asyncio/client.py", line 677, in execute_command
    return await conn.retry.call_with_retry(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gervasio/.pyenv/versions/api/lib/python3.11/site-packages/redis/asyncio/retry.py", line 50, in call_with_retry
    return await do()
           ^^^^^^^^^^
  File "/Users/gervasio/.pyenv/versions/api/lib/python3.11/site-packages/redis/asyncio/client.py", line 652, in _send_command_parse_response
    return await self.parse_response(conn, command_name, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gervasio/.pyenv/versions/api/lib/python3.11/site-packages/redis/asyncio/client.py", line 698, in parse_response
    response = await connection.read_response()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/gervasio/.pyenv/versions/api/lib/python3.11/site-packages/redis/asyncio/connection.py", line 627, in read_response
    raise response from None
redis.exceptions.NoScriptError: No matching script.
```

that will only resolve once the process gets restarted. This is because the backend's `_sha` is already populated even if the current primary doesn't have the script present.

This PR clears the backend's `_sha` dictionary on reconnection. I'd be happy to pass a callback so that we're the ones having this functionality, but this feels like doing the right thing.