### PR TITLE
Fix scripts not getting created for SafeRedis

### DIFF
--- a/cashews/backends/redis/client.py
+++ b/cashews/backends/redis/client.py
@@ -34,6 +34,10 @@ class SafeRedis(_Redis):
     async def execute_command(self, command, *args: Any, **kwargs: Any):
         try:
             return await super().execute_command(command, *args, **kwargs)
+        except NoScriptError:
+            # used by register_script functionality
+            # if we do not reraise it, than a Script wrapper will not work as expect
+            raise
         except (
             RedisConnectionError,
             socket.gaierror,


### PR DESCRIPTION
## What

Adds the `NoScriptError` check/raise in `SafeRedis`, analogous to the change in `Redis` that was made in #355. 

## Why

Our Redis restarted for the first time (and thus cleared saved scripts) since we upgraded to include the changes in #355, and we started getting the following error printed in logs and caches never getting unlocked, spinning forever waiting for the unlock.

```
04:11:43 cashews.backends.redis.client ERROR   redis: can not execute command: EVALSHA
Traceback (most recent call last):
  File "/Users/nick/repos/cashews/cashews/backends/redis/client.py", line 38, in execute_command
    return await super().execute_command(command, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nick/repos/hellopatient/backend/.venv/lib/python3.13/site-packages/opentelemetry/instrumentation/redis/__init__.py", line 291, in _async_traced_execute_command
    response = await func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nick/repos/hellopatient/backend/.venv/lib/python3.13/site-packages/redis/asyncio/client.py", line 677, in execute_command
    return await conn.retry.call_with_retry(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/Users/nick/repos/hellopatient/backend/.venv/lib/python3.13/site-packages/redis/asyncio/retry.py", line 50, in call_with_retry
    return await do()
           ^^^^^^^^^^
  File "/Users/nick/repos/hellopatient/backend/.venv/lib/python3.13/site-packages/redis/asyncio/client.py", line 652, in _send_command_parse_response
    return await self.parse_response(conn, command_name, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nick/repos/hellopatient/backend/.venv/lib/python3.13/site-packages/redis/asyncio/client.py", line 698, in parse_response
    response = await connection.read_response()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nick/repos/hellopatient/backend/.venv/lib/python3.13/site-packages/redis/asyncio/connection.py", line 627, in read_response
    raise response from None
redis.exceptions.NoScriptError: No matching script. Please use EVAL.
```

It seems that the new flow after #355 is to let the script [get created by the redis lib](https://github.com/redis/redis-py/blob/master/redis/commands/core.py#L5799-L5806) upon getting the `NoScriptError` as we no longer explicitly call `script_load`. But when using `SafeRedis` rather than Redis, the error was getting swallowed and it was just returning `None` from `client.evalsha` rather than throwing, so it never triggers the except block to create the script. After these changes it does.