### PR TITLE
Add type hints for cache.setup and in-memory backend

### DIFF
--- a/cashews/wrapper/__init__.py
+++ b/cashews/wrapper/__init__.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import ClassVar
+
 from cashews.backends.interface import _BackendInterface
-from cashews.decorators import context_cache_detect
+from cashews.decorators import CacheDetect, context_cache_detect
 
 from .backend_settings import register_backend  # noqa
 from .callback import CallbackWrapper
@@ -23,4 +28,4 @@ class Cache(
     DecoratorsWrapper,
     _BackendInterface,
 ):
-    detect = context_cache_detect
+    detect: ClassVar[AbstractContextManager[CacheDetect]] = context_cache_detect

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,3 +24,9 @@ ignore_missing_imports = True
 
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True
+
+[mypy-bitarray.*]
+ignore_missing_imports = True
+
+[mypy-xxhash.*]
+ignore_missing_imports = True


### PR DESCRIPTION
An idea is to make lib pass all mypy checks in strict mode.

Generated by Claude: 

> Added type hints respecting Python 3.9+ and mypy strict mode:
> 
> - cashews/wrapper/wrapper.py:
>   * Added proper type hints to Wrapper class methods
>   * Typed middlewares parameters as tuple[Middleware, ...]
>   * Added return types for _with_middlewares and _with_middlewares_for_backend
>   * Added Any type hints to kwargs parameters
> 
> - cashews/backends/memory.py:
>   * Added comprehensive type hints to Memory backend
>   * Typed store OrderedDict with proper key-value types
>   * Added return type annotations to all methods
>   * Typed internal variables and method parameters
> 
> - cashews/wrapper/__init__.py:
>   * Added type annotation for Cache.detect class variable
>   * Imported required types from typing module
> 
> - mypy.ini:
>   * Added ignore rules for bitarray and xxhash missing imports