### PR TITLE
Fix ContextVar LookupError in cross-context usage

### DIFF
--- a/cashews/backends/interface.py
+++ b/cashews/backends/interface.py
@@ -180,8 +180,7 @@ class ControlMixin:
     enable_by_default = True
 
     def __init__(self, *args, **kwargs) -> None:
-        self.__disable: ContextVar[set[Command]] = ContextVar(str(id(self)))
-        self.__disable.set(set())
+        self.__disable: ContextVar[set[Command]] = ContextVar(str(id(self)), default=set())
         self._control_set = False
         super().__init__(*args, **kwargs)
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from cashews import Cache
+from cashews.commands import Command
 
 
 async def test_issue_382():
@@ -15,3 +16,42 @@ async def test_issue_382():
         return asyncio.run(get_item(item_id))
 
     await asyncio.get_running_loop().run_in_executor(None, sync_get_item, 123)
+
+
+async def test_control_mixin_cross_context():
+    """Test that ControlMixin's ContextVar works across different async contexts.
+
+    This simulates the FastAPI lifespan pattern where cache.setup() is called in one
+    context (lifespan) and cache operations are called in different contexts (HTTP requests).
+    """
+    cache = Cache()
+
+    # Setup cache in one context (simulating FastAPI lifespan)
+    cache.setup("mem://")
+    cache.enable()  # This calls self.__disable.get() internally
+
+    @cache(ttl=60, key="test:{value}")
+    async def cached_func(value: int):
+        return f"result_{value}"
+
+    # Test in a different async context (simulating HTTP request)
+    async def test_in_new_context():
+        # This should not raise LookupError when checking if cache is enabled/disabled
+        result = await cached_func(123)
+        assert result == "result_123"
+
+        # Test disable/enable in new context
+        cache.disable(Command.SET)
+        assert cache.is_disable(Command.SET)
+
+        cache.enable(Command.SET)
+        assert cache.is_enable(Command.SET)
+
+        return result
+
+    def sync_runner():
+        return asyncio.run(test_in_new_context())
+
+    # Run in executor with new event loop (different context)
+    result = await asyncio.get_running_loop().run_in_executor(None, sync_runner)
+    assert result == "result_123"


### PR DESCRIPTION
  ## Summary
  Fixes a regression introduced in v7.4.2 that causes `LookupError` when using cashews with FastAPI's
  lifespan pattern or other cross-context scenarios.

  ## Problem
  Version 7.4.2 (commit a47f8ce) changed `ControlMixin.__init__` from:
  ```python
  self.__disable: ContextVar[set[Command]] = ContextVar(str(id(self)), default=set())
  to:
  self.__disable: ContextVar[set[Command]] = ContextVar(str(id(self)))
  self.__disable.set(set())

  This breaks cross-context usage because:
  - .set() only affects the current async context
  - When cache operations run in different contexts (e.g., HTTP requests after setup in lifespan),
  .get() raises LookupError because there's no value and no default

  This is the same issue as #382, which was fixed for key_context.py in PR #383 (commit e22d2a7), but
  the fix was not applied to ControlMixin.

  Solution

  Restore the default=set() parameter to the ContextVar constructor. This ensures .get() returns a
  default value in all async contexts, not just where .set() was called.

  Changes

  - Restored default=set() parameter in cashews/backends/interface.py:183
  - Removed redundant self.__disable.set(set()) call
  - Added test_control_mixin_cross_context to verify the fix and prevent future regressions

  Testing

  - All existing tests pass (54/67 in test_disable_control.py, 13 fail due to missing optional
  diskcache dependency)
  - New test test_control_mixin_cross_context specifically tests cross-context behavior
  - Verified test fails without the fix (LookupError) and passes with the fix

  Related

  - Fixes the same root cause as #382 / PR #383
  - Affects users using FastAPI lifespan pattern or similar cross-context scenarios